### PR TITLE
HTTP download breaks if there are no single-quotes around the url and there are special characters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -302,7 +302,7 @@ class splunk (
   if $splunk::install_source != '' {
 
     $install_command = $::operatingsystem ? {
-      /(?i:Debian|Ubuntu|Mint)/            => "wget ${splunk::install_source} -O /tmp/splunk.deb ; dpkg -i /tmp/splunk.deb",
+      /(?i:Debian|Ubuntu|Mint)/            => "wget \'${splunk::install_source}\' -O /tmp/splunk.deb ; dpkg -i /tmp/splunk.deb",
       /(?i:RedHat|Centos|Scientific|Suse)/ => "rpm -U ${splunk::install_source}",
     }
 


### PR DESCRIPTION
I've added single quotes for this fix.
