### PR TITLE
Remove the splunk package from /tmp after install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -318,7 +318,7 @@ class splunk (
   if $splunk::install_source != '' {
 
     $install_command = $::operatingsystem ? {
-      /(?i:Debian|Ubuntu|Mint)/                               => "wget \'${splunk::install_source}\' -O /tmp/splunk.deb ; dpkg -i /tmp/splunk.deb",
+      /(?i:Debian|Ubuntu|Mint)/                               => "wget \'${splunk::install_source}\' -O /tmp/puppet-splunk.deb ; dpkg -i /tmp/puppet-splunk.deb ; rm -f /tmp/puppet-splunk.deb",
       /(?i:RedHat|Centos|Scientific|Suse|OracleLinux|Amazon)/ => "rpm -U ${splunk::install_source}",
     }
 


### PR DESCRIPTION
If we're running on a Debian family OS, we have to download the file to
a temporary location before we can pass it into dpkg.  This changes the
existing behavior to rm that file after it's installed and also changes
the name of the temporary file to indicate that it was created by
puppet.
