### PR TITLE
Move puppet_manage_package script to splunk basedir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -323,14 +323,14 @@ class splunk (
     }
 
     exec { 'splunk_manage_package':
-      command     => '/root/puppet_manage_package',
+      command     => "${splunk::basedir}/puppet_manage_package",
       refreshonly => true,
       before      => Package['splunk'],
     }
 
     file { 'splunk_manage_package':
       ensure   => present,
-      path     => '/root/puppet_manage_package',
+      path     => "${splunk::basedir}/puppet_manage_package",
       mode     => '0700',
       owner    => 'root',
       group    => 'root',
@@ -339,6 +339,9 @@ class splunk (
       notify   => Exec['splunk_manage_package'],
     }
 
+    file { $splunk::basedir:
+      ensure => directory
+    }
   }
 
   package { 'splunk':


### PR DESCRIPTION
The script to install splunk packages was being stored in root's home
directory, presumably because at the time it's created, the splunk
packages haven't been installed and so they haven't created /opt/splunk.
This commit puts the splunk basedir under puppet management if it's
managing the packages and then puts the puppet_manage_package script in
that directory.
