### PR TITLE
Fix accept license argument

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -356,7 +356,7 @@ class splunk (
   }
 
   exec { 'splunk_create_service':
-    command  => "${splunk::basedir}/bin/splunk enable boot-start --accept-license --answer-yes --no-prompt",
+    command  => "${splunk::basedir}/bin/splunk --accept-license enable boot-start --answer-yes --no-prompt",
     creates  => '/etc/init.d/splunk',
     require  => Package['splunk'],
   }


### PR DESCRIPTION
It appears that the --accept-license argument has to occur at the
beginning of the line, or it's ignored, at least with version 6.0.3 of
the universal forwarder.
