### PR TITLE
Set the HOME environment variable if it's not set

### DIFF
--- a/templates/add_forward_server.erb
+++ b/templates/add_forward_server.erb
@@ -1,6 +1,12 @@
 #!/bin/sh
 # File Managed by Puppet
 
+if [ -z "$HOME" ]; then
+  # If $HOME isn't set, then set it to /tmp, because otherwise splunk will
+  # complains about not being able to cache auth tokens.
+  export HOME=/tmp
+fi
+
 # Adding forward servers
 <% @forward_server.each do |fs| -%>
 <%= scope.lookupvar('splunk::basedir') %>/bin/splunk add forward-server <%= fs %> --accept-license --answer-yes --auto-ports --no-prompt -auth admin:<%= scope.lookupvar('splunk::admin_password') %>
@@ -8,3 +14,7 @@
 
 # Service restart (done here to skip Puppet dependencies hell)
 /etc/init.d/splunk restart
+
+if [ "$HOME" = "/tmp" -a -d /tmp/.splunk ]; then
+  rm -f /tmp/.splunk/authToken_*
+fi

--- a/templates/add_monitor.erb
+++ b/templates/add_monitor.erb
@@ -1,6 +1,12 @@
 #!/bin/sh
 # File Managed by Puppet
 
+if [ -z "$HOME" ]; then
+  # If $HOME isn't set, then set it to /tmp, because otherwise splunk will
+  # complains about not being able to cache auth tokens.
+  export HOME=/tmp
+fi
+
 # Removing existing paths
 for a in $(<%= scope.lookupvar('splunk::basedir') %>/bin/splunk list monitor -auth admin:<%= scope.lookupvar('splunk::admin_password') %> | fgrep -v -i splunk | fgrep "/") ; do
 <%= scope.lookupvar('splunk::basedir') %>/bin/splunk remove monitor $a
@@ -11,3 +17,6 @@ done
 <%= scope.lookupvar('splunk::basedir') %>/bin/splunk add monitor <%= mon %> --accept-license --answer-yes --no-prompt -auth admin:<%= scope.lookupvar('splunk::admin_password') %> <%= scope.lookupvar('splunk::real_monitor_sourcetype') %>
 <% end -%>
 
+if [ "$HOME" = "/tmp" -a -d /tmp/.splunk ]; then
+  rm -f /tmp/.splunk/authToken_*
+fi

--- a/templates/change_admin_password.erb
+++ b/templates/change_admin_password.erb
@@ -1,6 +1,15 @@
 #!/bin/sh
 # File Managed by Puppet
 
+if [ -z "$HOME" ]; then
+  # If $HOME isn't set, then set it to /tmp, because otherwise splunk will
+  # complains about not being able to cache auth tokens.
+  export HOME=/tmp
+fi
+
 # Setting Admin password for the first time
 <%= scope.lookupvar('splunk::basedir') %>/bin/splunk edit user admin -password <%= scope.lookupvar('splunk::admin_password') %> --accept-license --answer-yes --no-prompt -auth admin:changeme
 
+if [ "$HOME" = "/tmp" -a -d /tmp/.splunk ]; then
+  rm -f /tmp/.splunk/authToken_*
+fi


### PR DESCRIPTION
The Splunk command-line tools want to cache auth tokens into the user's
home directory.  If the HOME directory is not set, then we set it to
/tmp and export the variable to prevent unnecessary failures. 
