### PR TITLE
Unmanage puppet_manage_package user & group

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -332,8 +332,6 @@ class splunk (
       ensure   => present,
       path     => "${splunk::basedir}/puppet_manage_package",
       mode     => '0700',
-      owner    => 'root',
-      group    => 'root',
       content  => template('splunk/manage_package.erb'),
       before   => Package['splunk'] ,
       notify   => Exec['splunk_manage_package'],


### PR DESCRIPTION
The splunk package install chowns everything under /opt/splunkforwarder
to the splunk user.  We can't have this file be owned by the splunk user
when we create it, since the package hasn't been installed and the user
doens't exist yet.  We'll let Puppet create it with the default
(probably root) and then let the Splunk package handle it from there.
This way Puppet and Splunk don't bicker over who should manage the
ownership.
