### PR TITLE
Quote monitor to avoid expanding wildcards

### DIFF
--- a/templates/add_monitor.erb
+++ b/templates/add_monitor.erb
@@ -8,6 +8,6 @@ done
 
 # Adding paths
 <% @monitor_path.each do |mon| -%>
-<%= scope.lookupvar('splunk::basedir') %>/bin/splunk add monitor <%= mon %> --accept-license --answer-yes --no-prompt -auth admin:<%= scope.lookupvar('splunk::admin_password') %> <%= scope.lookupvar('splunk::real_monitor_sourcetype') %>
+<%= scope.lookupvar('splunk::basedir') %>/bin/splunk add monitor '<%= mon %>' --accept-license --answer-yes --no-prompt -auth admin:<%= scope.lookupvar('splunk::admin_password') %> <%= scope.lookupvar('splunk::real_monitor_sourcetype') %>
 <% end -%>
 


### PR DESCRIPTION
To allow passing in wildcarded paths, we need to quote them when passing
them into the splunk add monitor command, so that splunk gets the
pattern, not the expansion.
