### PR TITLE
Fix string iteration on ruby 1.9

### DIFF
--- a/templates/add_forward_server.erb
+++ b/templates/add_forward_server.erb
@@ -8,7 +8,7 @@ if [ -z "$HOME" ]; then
 fi
 
 # Adding forward servers
-<% @forward_server.each do |fs| -%>
+<% Array(@forward_server).each do |fs| -%>
 <%= scope.lookupvar('splunk::basedir') %>/bin/splunk add forward-server <%= fs %> --accept-license --answer-yes --auto-ports --no-prompt -auth admin:<%= scope.lookupvar('splunk::admin_password') %>
 <% end -%>
 

--- a/templates/add_monitor.erb
+++ b/templates/add_monitor.erb
@@ -13,7 +13,7 @@ for a in $(<%= scope.lookupvar('splunk::basedir') %>/bin/splunk list monitor -au
 done
 
 # Adding paths
-<% @monitor_path.each do |mon| -%>
+<% Array(@monitor_path).each do |mon| -%>
 <%= scope.lookupvar('splunk::basedir') %>/bin/splunk add monitor '<%= mon %>' --accept-license --answer-yes --no-prompt -auth admin:<%= scope.lookupvar('splunk::admin_password') %> <%= scope.lookupvar('splunk::real_monitor_sourcetype') %>
 <% end -%>
 


### PR DESCRIPTION
Pre ruby-1.9 you could call "string".each and it would call the block once.
Ruby 1.9 don't have an each method on the String class. Work around that by
explicitly coaxing the forward_server and monitor_path arguments into arrays.
