### PR TITLE
Reworked install_source package handling

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -473,7 +473,7 @@ class splunk (
   }
 
   # Local configuration files for which a template can be provided
-  if $splunk::template_inputs {
+  if $splunk::template_inputs and $splunk::template_inputs != '' {
     file { 'splunk_inputs.conf':
       ensure  => $splunk::manage_file,
       path    => "${splunk::basedir}/etc/system/local/inputs.conf",
@@ -488,7 +488,7 @@ class splunk (
     }
   }
 
-  if $splunk::template_outputs {
+  if $splunk::template_outputs and $splunk::template_outputs != '' {
     file { 'splunk_outputs.conf':
       ensure  => $splunk::manage_file,
       path    => "${splunk::basedir}/etc/system/local/outputs.conf",
@@ -503,7 +503,7 @@ class splunk (
     }
   }
 
-  if $splunk::template_server {
+  if $splunk::template_server and $splunk::template_server != '' {
     file { 'splunk_server.conf':
       ensure  => $splunk::manage_file,
       path    => "${splunk::basedir}/etc/system/local/server.conf",
@@ -518,7 +518,7 @@ class splunk (
     }
   }
 
-  if $splunk::template_web {
+  if $splunk::template_web and $splunk::template_web != '' {
     file { 'splunk_web.conf':
       ensure  => $splunk::manage_file,
       path    => "${splunk::basedir}/etc/system/local/web.conf",


### PR DESCRIPTION
This changes the handling of the install_source to be more robust and
idempotent. It retrieves the package via wget and keeps the package in a
known location.  It then uses the Puppet package type with an rpm or
dpkg provider to install the local package.  This means that Puppet will
handle upgrades and checking for installation automatically.

Without this patch, we frequently ran into problems where the
puppet_manage_package script would be run, but fail for some reason.
Since it was a refreshonly exec, it would never be run again, and then
it would fall through and attempt to install the package via apt.  This
would lead to very confusing debugging sessions, since most people
didn't know it shouldn't be installed via apt anyway.