### PR TITLE
Set home directory in admin password change script

### DIFF
--- a/templates/change_admin_password.erb
+++ b/templates/change_admin_password.erb
@@ -1,11 +1,7 @@
 #!/bin/sh
 # File Managed by Puppet
 
-if [ -z "$HOME" ]; then
-  # If $HOME isn't set, then set it to /tmp, because otherwise splunk will
-  # complains about not being able to cache auth tokens.
-  export HOME=/tmp
-fi
+export HOME=/tmp
 
 # Setting Admin password for the first time
 <%= scope.lookupvar('splunk::basedir') %>/bin/splunk edit user admin -password <%= scope.lookupvar('splunk::admin_password') %> --accept-license --answer-yes --no-prompt -auth admin:changeme


### PR DESCRIPTION
When the splunk process runs as a non root user and the script runs as
root (such as running from Puppet). The splunk command line fails and
complains that it does not have permissions to create the
authentication token in roots home directory.

Since this script should be a one of, setting to root to /tmp and
deleting the token after password has changed should be enough and safe.

@yasn77