### PR TITLE
FIX #39 - splunk download path should not be a file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -363,7 +363,7 @@ class splunk (
     }
 
     file { "${splunk::basedir}/${package_provider}":
-      ensure => $splunk::manage_file,
+      ensure => $splunk::manage_directory,
       owner  => $splunk::config_file_owner,
       group  => $splunk::config_file_group,
       mode   => '0755',


### PR DESCRIPTION
as per #39 for new universal forwarder installs the process creates the download directory as a file and not a directory

very simple 1 line fix to resolve this :)